### PR TITLE
CI: test shell workflows

### DIFF
--- a/.github/workflows/beautysh.yml
+++ b/.github/workflows/beautysh.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
           cache: pip
           cache-dependency-path: .github/workflows/es-progress/.github/requirements.txt
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,3 +11,10 @@ jobs:
     uses: ./.github/workflows/prettier.yml
     with:
       pattern: "**/*.yml"
+  test-beautysh:
+    name: Test workflow (beautysh)
+    needs: format
+    uses: ./.github/workflows/beautysh.yml
+    with:
+      dir: tests/workflows
+      params: --force-function-style fnpar --indent-size 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,3 +18,11 @@ jobs:
     with:
       dir: tests/workflows
       params: --force-function-style fnpar --indent-size 2
+  test-shellcheck:
+    name: Test workflow (shellcheck)
+    needs: format
+    uses: ./.github/workflows/shellcheck.yml
+    with:
+      dir: tests/workflows
+      severity: error
+      params:

--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ jobs:
       dir: bin/
       severity: error
       # Don't pass any exra args to shellcheck
-      shellcheck_params:
+      params:
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     uses: es-progress/.github/.github/workflows/beautysh.yml@main
     with:
       dir: bin/
-      beautysh_params: --force-function-style fnpar --indent-size 2
+      params: --force-function-style fnpar --indent-size 2
 ```
 
 ### mkdocs.yml

--- a/tests/workflows/shell.sh
+++ b/tests/workflows/shell.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#################
+## Test script ##
+#################
+
+function _msg() {
+  local msg="${1?:"Message missing"}"
+  echo "${msg}"
+}
+
+# Strict mode
+set -eufo pipefail
+IFS=$'\n\t'
+
+_msg Testing
+
+exit 0


### PR DESCRIPTION
test workflows by running them:
- beautysh
- shellcheck

It seems `beautysh` is not compatible with Python 3.12 so python versin is pinned to 3.11 https://github.com/lovesegfault/beautysh/issues/248