### PR TITLE
CI/shellcheck: don't pass arguments to shellcheck by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "**.yml"
+      - "tests/**"
 jobs:
   format:
     name: Check format
@@ -43,5 +44,5 @@ jobs:
     uses: ./.github/workflows/shellcheck.yml
     with:
       dir: tests/workflows
-      severity: error
+      severity: info
       params:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,3 @@ jobs:
     with:
       dir: tests/workflows
       severity: info
-      params:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,7 +16,7 @@ on:
         description: Options to shellcheck
         type: string
         required: false
-        default: --format gcc --external-sources --shell bash --enable "add-default-case,avoid-nullary-conditions,check-extra-masked-returns,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets,require-variable-braces"
+        default:
 jobs:
   shellcheck:
     name: Run shellcheck

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ params:
   description: Options to shellcheck
   type: string
   required: false
-  default: --format gcc --external-sources --shell bash --enable "add-default-case,avoid-nullary-conditions,check-extra-masked-returns,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets,require-variable-braces"
+  default:
 ```
 
 **Example**
@@ -218,6 +218,6 @@ jobs:
     with:
       dir: bin/
       severity: error
-      # Don't pass any exra args to shellcheck
-      params:
+      # Omit params, don't need any extra args to shellcheck
+      # params:
 ```

--- a/tests/workflows/shellcheckrc
+++ b/tests/workflows/shellcheckrc
@@ -1,0 +1,10 @@
+shell=bash
+external-sources=true
+enable=add-default-case
+enable=avoid-nullary-conditions
+enable=check-extra-masked-returns
+enable=check-set-e-suppressed
+enable=deprecate-which
+enable=quote-safe-variables
+enable=require-double-brackets
+enable=require-variable-braces

--- a/tests/workflows/test.sh
+++ b/tests/workflows/test.sh
@@ -12,6 +12,21 @@ function _msg() {
 set -eufo pipefail
 IFS=$'\n\t'
 
+for f in *.m3u
+do
+  grep -qi "hq.*mp3" "$f" \
+    && echo -e "'Playlist ${f} contains a HQ file in mp3 format'"
+done
+
+case "$1" in
+  "Testing")
+    _msg "Testing"
+    ;;
+  "Production")
+    _msg "Production"
+    ;;
+esac
+
 _msg Testing
 
 exit 0

--- a/tests/workflows/test.sh
+++ b/tests/workflows/test.sh
@@ -25,6 +25,7 @@ case "$1" in
   "Production")
     _msg "Production"
     ;;
+  *) ;;
 esac
 
 _msg Testing


### PR DESCRIPTION
You can still pass options to `shellcheck` with `params` input, but by default there will be none.
Preferably use `.shellcheckrc` in your project root for that.