### PR TITLE
CI/beautysh: remove --variable-style braces from default

### DIFF
--- a/.github/workflows/beautysh.yml
+++ b/.github/workflows/beautysh.yml
@@ -11,7 +11,7 @@ on:
         description: Options to beautysh
         type: string
         required: false
-        default: --force-function-style paronly --variable-style braces
+        default: --force-function-style paronly
 jobs:
   beautysh:
     name: Run beautysh


### PR DESCRIPTION
Until
https://github.com/lovesegfault/beautysh/issues/267
and
https://github.com/lovesegfault/beautysh/issues/268
is not resolved, `--variable-style braces` is not ready to be added as default option